### PR TITLE
Added / Mentioning the pdm-bump plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [pdm-publish](https://github.com/branchvincent/pdm-publish) - A PDM plugin to publish to PyPI
 - [pdm-venv](https://github.com/pdm-project/pdm-venv) - A plugin for pdm that enables virtualenv management
 - [pdm-version](https://github.com/abersheeran/pdm-version) - Make `pdm version` like `poetry version`
+- [pdm-bump](https://github.com/carstencodes/pdm-bump) - A PDM plugin that behaves like [bump2version](https://github.com/c4urself/bump2version) relying on PEP440 compliant versions. 
 
 ## Eco-system
 


### PR DESCRIPTION
Added the link to a PDM plugin that just behaves like bump2version (https://github.com/c4urself/bump2version)

This resolves #1.